### PR TITLE
feat: added prettier support (closes #5)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,21 @@
+{
+    "semi": true,
+    "singleQuote": true,
+    "singleAttributePerLine": false,
+    "htmlWhitespaceSensitivity": "css",
+    "printWidth": 150,
+    "plugins": [
+        "prettier-plugin-organize-imports",
+        "prettier-plugin-tailwindcss"
+    ],
+    "tailwindFunctions": ["clsx", "cn"],
+    "tabWidth": 4,
+    "overrides": [
+        {
+            "files": "**/*.yml",
+            "options": {
+                "tabWidth": 2
+            }
+        }
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
                 "axios": "^1.8.2",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^1.2.0",
+                "prettier": "^3.5.3",
                 "tailwindcss": "^4.0.0",
                 "typescript": "^5.8.3",
                 "vite": "^6.2.4"
@@ -1075,6 +1076,21 @@
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "dev": true
+        },
+        "node_modules/prettier": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+            "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
         },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,16 @@
     "type": "module",
     "scripts": {
         "build": "vite build",
-        "dev": "vite"
+        "dev": "vite",
+        "format": "prettier --write resources/",
+        "format:check": "prettier --check resources/"
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
         "axios": "^1.8.2",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^1.2.0",
+        "prettier": "^3.5.3",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.8.3",
         "vite": "^6.2.4"


### PR DESCRIPTION
It's a bit overwhelming to go through everything Prettier offers, so I'm adapting my configuration from the following sources:

- [Laravel React Starter Kit – .prettierrc](https://github.com/laravel/react-starter-kit/blob/main/.prettierrc)  
- [Laravel Vue Starter Kit – .prettierrc](https://github.com/laravel/vue-starter-kit/blob/main/.prettierrc)
